### PR TITLE
Simplify SHA1/MD5 fingerprint generators

### DIFF
--- a/helpers/fingerprint.go
+++ b/helpers/fingerprint.go
@@ -4,6 +4,7 @@ import (
 	"crypto/md5"
 	"crypto/sha1"
 	"fmt"
+	"strings"
 
 	"golang.org/x/crypto/ssh"
 )
@@ -13,21 +14,14 @@ const SHA1_FINGERPRINT_LENGTH = 59
 
 func MD5Fingerprint(key ssh.PublicKey) string {
 	md5sum := md5.Sum(key.Marshal())
-	return hex(md5sum[:])
+	return colonize(fmt.Sprintf("% x", md5sum))
 }
 
 func SHA1Fingerprint(key ssh.PublicKey) string {
 	sha1sum := sha1.Sum(key.Marshal())
-	return hex(sha1sum[:])
+	return colonize(fmt.Sprintf("% x", sha1sum))
 }
 
-func hex(data []byte) string {
-	var fingerprint string
-	for i := 0; i < len(data); i++ {
-		fingerprint = fmt.Sprintf("%s%0.2x", fingerprint, data[i])
-		if i != len(data)-1 {
-			fingerprint = fingerprint + ":"
-		}
-	}
-	return fingerprint
+func colonize(s string) string {
+	return strings.Replace(s, " ", ":", -1)
 }


### PR DESCRIPTION
- Remove the very curious usage of '[:]', which was used because the hex
  function requires []byte, but md5/sha1.Sum give you [Size]byte, and
  [:] will return []byte.
- Stop iterating through the bytes to construct the colonized string;
  use fmt.Sprintf("% x", data) as shown in Golang docs (and replace the
  spaces with colons): https://play.golang.org/p/e7W5FVB-hW
