### PR TITLE
Rewrite listen address using CF_INSTANCE_PORTS on Windows

### DIFF
--- a/cmd/ssh-proxy/main_test.go
+++ b/cmd/ssh-proxy/main_test.go
@@ -1,5 +1,3 @@
-// +build !windows
-
 package main_test
 
 import (

--- a/cmd/sshd/main.go
+++ b/cmd/sshd/main.go
@@ -11,7 +11,6 @@ import (
 	"github.com/cloudfoundry-incubator/diego-ssh/authenticators"
 	"github.com/cloudfoundry-incubator/diego-ssh/daemon"
 	"github.com/cloudfoundry-incubator/diego-ssh/keys"
-	"github.com/cloudfoundry-incubator/diego-ssh/server"
 	"github.com/pivotal-golang/lager"
 	"github.com/tedsuo/ifrit"
 	"github.com/tedsuo/ifrit/grouper"
@@ -63,7 +62,7 @@ func main() {
 	}
 
 	sshDaemon := daemon.New(logger, serverConfig, nil, newChannelHandlers())
-	server := server.NewServer(logger, *address, sshDaemon)
+	server, err := createServer(logger, *address, sshDaemon)
 
 	members := grouper.Members{
 		{"sshd", server},

--- a/cmd/sshd/main_unix.go
+++ b/cmd/sshd/main_unix.go
@@ -1,0 +1,16 @@
+// +build !windows
+
+package main
+
+import (
+	"github.com/cloudfoundry-incubator/diego-ssh/server"
+	"github.com/pivotal-golang/lager"
+)
+
+func createServer(
+	logger lager.Logger,
+	address string,
+	sshDaemon server.ConnectionHandler,
+) (*server.Server, error) {
+	return server.NewServer(logger, address, sshDaemon), nil
+}

--- a/cmd/sshd/main_windows.go
+++ b/cmd/sshd/main_windows.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"encoding/json"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/cloudfoundry-incubator/diego-ssh/server"
+	"github.com/pivotal-golang/lager"
+)
+
+type PortMapping struct {
+	Internal int `json:"internal"`
+	External int `json:"external"`
+}
+
+func createServer(
+	logger lager.Logger,
+	address string,
+	sshDaemon server.ConnectionHandler,
+) (*server.Server, error) {
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return nil, err
+	}
+	jsonPortMappings := os.Getenv("CF_INSTANCE_PORTS")
+	var portMappings []PortMapping
+	json.Unmarshal([]byte(jsonPortMappings), &portMappings)
+	for _, mapping := range portMappings {
+		if strconv.Itoa(mapping.Internal) == port {
+			port = strconv.Itoa(mapping.External)
+		}
+	}
+	address = strings.Join([]string{host, port}, ":")
+	return server.NewServer(logger, address, sshDaemon), err
+}


### PR DESCRIPTION
Hey Diegons,

We're looking to change the way we handle the lack of internal/external port mapping on Windows. We currently have a [nasty hack](https://github.com/cloudfoundry/garden-windows/blob/ac98420402a47f0b63f98c96361d23063d8db603/Containerizer/Containerizer/Services/Implementations/RunService.cs#L81-L89) in place in part of GardenWindows application to selectively rewrite the `-address` flag passed to _any_ program that happens to be run with an `-address` argument in its ProcessSpec.

This became an issue when you all wanted to change the SSH daemon to run via the Launcher, since that meant that it was now the arguments in the ProcessSpec no longer matched our expectations. This change moves the `-address` rewriting to inside the SSH daemon itself, using `CF_INSTANCE_PORTS` to do the translation.

Ben & Matt
