### PR TITLE
Use updated sftp Server constructor

### DIFF
--- a/handlers/session_channel_handler.go
+++ b/handlers/session_channel_handler.go
@@ -313,18 +313,19 @@ func (sess *session) handleSubsystemRequest(request *ssh.Request) {
 		return
 	}
 
+	lagerWriter := helpers.NewLagerWriter(logger.Session("sftp-server"))
+	sftpServer, err := sftp.NewServer(sess.channel, sess.channel, sftp.WithDebug(lagerWriter))
+	if err != nil {
+		logger.Error("sftp-new-server-failed", err)
+		if request.WantReply {
+			request.Reply(false, nil)
+		}
+		return
+	}
+
 	if request.WantReply {
 		request.Reply(true, nil)
 	}
-
-	sftpServer, err := sftp.NewServer(
-		sess.channel,
-		sess.channel,
-		helpers.NewLagerWriter(logger.Session("sftp-server")),
-		1,
-		false,
-		os.Getenv("HOME"),
-	)
 
 	logger.Info("starting-server")
 	go func() {


### PR DESCRIPTION
The sftp package has undergone some changes to make it easier to wire in server options. This updates our code to use the new constructor format.

If/when merged, please bump the src/github.com/pkg/sftp submodule in diego release to the [current master](https://github.com/pkg/sftp/tree/e84cc8c755ca39b7b64f510fe1fffc1b51f210a5).
