### PR TITLE
Don't try to syscall.exec on Windows

### DIFF
--- a/cmd/sshd/main.go
+++ b/cmd/sshd/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"runtime"
 	"strings"
 	"syscall"
 
@@ -100,7 +101,7 @@ func main() {
 		exec = true
 	}
 
-	if exec {
+	if exec && runtime.GOOS != "windows" {
 		os.Setenv("SSHD_HOSTKEY", hostKeyPEM)
 		os.Setenv("SSHD_AUTHKEY", authorizedKeyValue)
 


### PR DESCRIPTION
The exec syscall does not exist on Windows.

[#135953721]

Signed-off-by: Matthew Horan <mhoran@pivotal.io>