### PR TITLE
Use a build flag to opt-in to external port mapping

### DIFF
--- a/cmd/sshd/helpers_external_port_test.go
+++ b/cmd/sshd/helpers_external_port_test.go
@@ -1,0 +1,30 @@
+// +build external
+
+package main_test
+
+import (
+	"fmt"
+	"os"
+
+	"code.cloudfoundry.org/diego-ssh/cmd/sshd/testrunner"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
+	"github.com/tedsuo/ifrit"
+)
+
+func buildSshd() string {
+	sshd, err := gexec.Build("code.cloudfoundry.org/diego-ssh/cmd/sshd", "-race", "-tags", "external")
+	Expect(err).NotTo(HaveOccurred())
+	return sshd
+}
+
+func startSshd(sshdPath string, args testrunner.Args, address string, port int) (ifrit.Runner, ifrit.Process) {
+	args.Address = fmt.Sprintf("%s:2222", address)
+	runner := testrunner.New(sshdPath, args)
+	runner.Command.Env = append(
+		os.Environ(),
+		fmt.Sprintf(`CF_INSTANCE_PORTS=[{"external":%d,"internal":%d}]`, port, 2222),
+	)
+	process := ifrit.Invoke(runner)
+	return runner, process
+}

--- a/cmd/sshd/helpers_internal_port_test.go
+++ b/cmd/sshd/helpers_internal_port_test.go
@@ -1,0 +1,25 @@
+// +build !external
+
+package main_test
+
+import (
+	"fmt"
+
+	"code.cloudfoundry.org/diego-ssh/cmd/sshd/testrunner"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
+	"github.com/tedsuo/ifrit"
+)
+
+func buildSshd() string {
+	sshd, err := gexec.Build("code.cloudfoundry.org/diego-ssh/cmd/sshd", "-race")
+	Expect(err).NotTo(HaveOccurred())
+	return sshd
+}
+
+func startSshd(sshdPath string, args testrunner.Args, address string, port int) (ifrit.Runner, ifrit.Process) {
+	args.Address = fmt.Sprintf("%s:%d", address, port)
+	runner := testrunner.New(sshdPath, args)
+	process := ifrit.Invoke(runner)
+	return runner, process
+}

--- a/cmd/sshd/main_external_port.go
+++ b/cmd/sshd/main_external_port.go
@@ -1,3 +1,5 @@
+// +build external
+
 package main
 
 import (

--- a/cmd/sshd/main_internal_port.go
+++ b/cmd/sshd/main_internal_port.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build !external
 
 package main
 

--- a/cmd/sshd/main_suite_test.go
+++ b/cmd/sshd/main_suite_test.go
@@ -26,8 +26,7 @@ func TestSSHDaemon(t *testing.T) {
 }
 
 var _ = SynchronizedBeforeSuite(func() []byte {
-	sshd, err := gexec.Build("code.cloudfoundry.org/diego-ssh/cmd/sshd", "-race")
-	Expect(err).NotTo(HaveOccurred())
+	sshd := buildSshd()
 
 	hostKey, err := keys.RSAKeyPairFactory.NewKeyPair(1024)
 	Expect(err).NotTo(HaveOccurred())

--- a/cmd/sshd/main_test.go
+++ b/cmd/sshd/main_test.go
@@ -61,7 +61,6 @@ var _ = Describe("SSH daemon", func() {
 
 	JustBeforeEach(func() {
 		args := testrunner.Args{
-			Address:       address,
 			HostKey:       string(hostKey),
 			AuthorizedKey: string(authorizedKey),
 
@@ -73,8 +72,7 @@ var _ = Describe("SSH daemon", func() {
 			InheritDaemonEnv:            inheritDaemonEnv,
 		}
 
-		runner = testrunner.New(sshdPath, args)
-		process = ifrit.Invoke(runner)
+		runner, process = startSshd(sshdPath, args, "127.0.0.1", sshdPort)
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
- there are now 4 ways diego-sshd can be built:
    1. windows + external port mapping
    2. windows + internal port mapping
    3. linux + external port mapping (not used)
    3. linux + internal port mapping

 - fix failing unit tests on Windows

[#148169141]

Signed-off-by: Matt Horan <mhoran@pivotal.io>