### PR TITLE
Enable `cf ssh` for Windows+Linux with 3rd Party Network Plugins

### DIFF
--- a/authenticators/permissions_builder.go
+++ b/authenticators/permissions_builder.go
@@ -62,7 +62,8 @@ func (pb *permissionsBuilder) createPermissions(
 		if mapping.ContainerPort == sshRoute.ContainerPort {
 			address := actual.Address
 			port := mapping.HostPort
-			if pb.useDirectInstanceAddr {
+			useInstanceAddr := pb.useDirectInstanceAddr || actual.AdvertisePreferenceForInstanceAddress
+			if useInstanceAddr {
 				address = actual.InstanceAddress
 				port = mapping.ContainerPort
 			}
@@ -72,7 +73,7 @@ func (pb *permissionsBuilder) createPermissions(
 				tlsAddress = fmt.Sprintf("%s:%d", actual.Address, mapping.HostTlsProxyPort)
 			}
 
-			if pb.useDirectInstanceAddr && mapping.ContainerTlsProxyPort > 0 {
+			if useInstanceAddr && mapping.ContainerTlsProxyPort > 0 {
 				tlsAddress = fmt.Sprintf("%s:%d", actual.InstanceAddress, mapping.ContainerTlsProxyPort)
 			}
 

--- a/cmd/ssh-proxy/main_test.go
+++ b/cmd/ssh-proxy/main_test.go
@@ -144,7 +144,7 @@ var _ = Describe("SSH proxy", func() {
 				Instance: &models.ActualLRP{
 					ActualLRPKey:         models.NewActualLRPKey(processGuid, 99, "some-domain"),
 					ActualLRPInstanceKey: models.NewActualLRPInstanceKey("some-instance-guid", "some-cell-id"),
-					ActualLRPNetInfo:     models.NewActualLRPNetInfo("127.0.0.1", "127.0.0.1", models.NewPortMappingWithTLSProxy(uint32(sshdPort), uint32(sshdContainerPort), uint32(sshdTLSPort), uint32(sshdContainerTLSPort))),
+					ActualLRPNetInfo:     models.NewActualLRPNetInfo("127.0.0.1", "127.0.0.1", false, models.NewPortMappingWithTLSProxy(uint32(sshdPort), uint32(sshdContainerPort), uint32(sshdTLSPort), uint32(sshdContainerTLSPort))),
 				},
 			},
 		}


### PR DESCRIPTION
#### PRs
This is a comprehensive set of PRs that must be merged at the same:

- [bbs](https://github.com/cloudfoundry/bbs/pull/39)
- [diego-ssh](https://github.com/cloudfoundry/diego-ssh/pull/45)
- [executor](https://github.com/cloudfoundry/executor/pull/46)
- [rep](https://github.com/cloudfoundry/rep/pull/28)
- [route-emitter](https://github.com/cloudfoundry/route-emitter/pull/14)

#### Changes

This change enables `rep` to advertise connection preference: Diego cell IP vs Instance (Container) IP.

Silk, the default container network plugin, prefers connecting to the Diego cell's IP address, and that's the default behavior.

Third party network plugins will now have the option to advertise the instance (container) IP address when they are placed on a separate overlay network.

To enable this behavior, set the `rep` BOSH job property `advertise_preference_for_instance_address` to true to direct `cf ssh` to use instance IP address.

This is a more fine-grained version of the `ssh-proxy` BOSH job property, `connect_to_instance_address`, which, when set to `true`, directs _all_ `cf ssh` connections to the instance's IP address, which is the desired behavior when _all_ instances are on the overlay network.

Fine-grained control is required for networks where not all instances are on the overlay networks, for example, networks with a mixture of Linux and Windows Diego cells.

By setting the preference for instance addresses on each `rep` job, heterogenous deployments can specify the the best/accessible address on the BOSH instance group level, allowing Linux cells to elect connecting to instance addresses and vice versa.

### Necessary Changes to `diego-release`

In addition to re-submoduling the repos with PRs, the following patch should be applied to `diego-release` to expose the property:

```diff
diff --git a/jobs/rep/spec b/jobs/rep/spec
index 4ce258dfb..7a33f3b16 100644
--- a/jobs/rep/spec
+++ b/jobs/rep/spec
@@ -91,6 +91,9 @@ properties:
   diego.rep.listen_addr_securable:
     description: "address where rep listens for LRP and task start auction requests"
     default: "0.0.0.0:1801"
+  diego.rep.advertise_preference_for_instance_address:
+    description: "advertise that containers managed by this rep are directly accessible on the infrastructure network at their instance address. Components like ssh-proxy or routers may use this property when determining how to connect to a container. Set this flag only when using a third-party container-networking solution that provides direct connectivity between containers and VMs"
+    default: false

   diego.ssl.skip_cert_verify:
     description: "when connecting over https, ignore bad ssl certificates"
diff --git a/jobs/rep/templates/rep.json.erb b/jobs/rep/templates/rep.json.erb
index e2d5f14ac..247cf0e6a 100644
--- a/jobs/rep/templates/rep.json.erb
+++ b/jobs/rep/templates/rep.json.erb
@@ -45,6 +45,7 @@
     container_proxy_trusted_ca_certs: p("containers.proxy.trusted_ca_certificates"),
     container_proxy_verify_subject_alt_name: p("containers.proxy.verify_subject_alt_name"),
     container_proxy_ads_addresses: p("containers.proxy.ads_addresses"),
+    advertise_preference_for_instance_address: p("diego.rep.advertise_preference_for_instance_address"),
     enable_unproxied_port_mappings: p("containers.proxy.enable_unproxied_port_mappings"),
     proxy_memory_allocation_mb: p("containers.proxy.additional_memory_allocation_mb"),
     container_proxy_path: "/var/vcap/packages/proxy",
diff --git a/jobs/rep_windows/spec b/jobs/rep_windows/spec
index f08581e4d..5c617f380 100644
--- a/jobs/rep_windows/spec
+++ b/jobs/rep_windows/spec
@@ -87,6 +87,9 @@ properties:
   diego.rep.listen_addr_securable:
     description: "address where rep listens for LRP and task start auction requests"
     default: "0.0.0.0:1801"
+  diego.rep.advertise_preference_for_instance_address:
+    description: "advertise that containers managed by this rep are directly accessible on the infrastructure network at their instance address. Components like ssh-proxy or routers may use this property when determining how to connect to a container. Set this flag only when using a third-party container-networking solution that provides direct connectivity between containers and VMs"
+    default: false

   diego.ssl.skip_cert_verify:
     description: "when connecting over https, ignore bad ssl certificates"
diff --git a/jobs/rep_windows/templates/rep.json.erb b/jobs/rep_windows/templates/rep.json.erb
index 17a17dd32..923c6526e 100644
--- a/jobs/rep_windows/templates/rep.json.erb
+++ b/jobs/rep_windows/templates/rep.json.erb
@@ -45,6 +45,7 @@
     container_proxy_trusted_ca_certs: p("containers.proxy.trusted_ca_certificates"),
     container_proxy_verify_subject_alt_name: p("containers.proxy.verify_subject_alt_name"),
     container_proxy_ads_addresses: p("containers.proxy.ads_addresses"),
+    advertise_preference_for_instance_address: p("diego.rep.advertise_preference_for_instance_address"),
     enable_unproxied_port_mappings: p("containers.proxy.enable_unproxied_port_mappings"),
     proxy_memory_allocation_mb: p("containers.proxy.additional_memory_allocation_mb"),
     container_proxy_path: "/var/vcap/packages/envoy_windows",
```

CC @cunnie @evanfarrar