### PR TITLE
Update bbs client calls with trace ID

### DIFF
--- a/authenticators/permissions_builder.go
+++ b/authenticators/permissions_builder.go
@@ -30,7 +30,7 @@ func (pb *permissionsBuilder) Build(logger lager.Logger, processGuid string, ind
 		ProcessGuid: processGuid,
 		Index:       &ind,
 	}
-	actualLRPs, err := pb.bbsClient.ActualLRPs(logger, filter)
+	actualLRPs, err := pb.bbsClient.ActualLRPs(logger, "", filter)
 	if err != nil {
 		return nil, err
 	} else if len(actualLRPs) > 1 {
@@ -39,7 +39,7 @@ func (pb *permissionsBuilder) Build(logger lager.Logger, processGuid string, ind
 		return nil, fmt.Errorf("no matching ActualLRP for ProcessGuid: %s, Index: %d", processGuid, ind)
 	}
 
-	desired, err := pb.bbsClient.DesiredLRPByProcessGuid(logger, processGuid)
+	desired, err := pb.bbsClient.DesiredLRPByProcessGuid(logger, "", processGuid)
 	if err != nil {
 		return nil, err
 	}

--- a/authenticators/permissions_builder_test.go
+++ b/authenticators/permissions_builder_test.go
@@ -89,14 +89,16 @@ var _ = Describe("PermissionsBuilder", func() {
 
 		It("gets information about the desired lrp referenced in the username", func() {
 			Expect(bbsClient.DesiredLRPByProcessGuidCallCount()).To(Equal(1))
-			_, guid := bbsClient.DesiredLRPByProcessGuidArgsForCall(0)
+			_, traceId, guid := bbsClient.DesiredLRPByProcessGuidArgsForCall(0)
+			Expect(traceId).To(BeEmpty())
 			Expect(guid).To(Equal("some-guid"))
 		})
 
 		It("gets information about the the actual lrp from the username", func() {
 			Expect(bbsClient.ActualLRPsCallCount()).To(Equal(1))
 
-			_, filter := bbsClient.ActualLRPsArgsForCall(0)
+			_, traceId, filter := bbsClient.ActualLRPsArgsForCall(0)
+			Expect(traceId).To(BeEmpty())
 			Expect(filter.ProcessGuid).To(Equal("some-guid"))
 			Expect(*filter.Index).To(BeEquivalentTo(1))
 		})


### PR DESCRIPTION
## Please provide the following information:

### What is this change about?

BBS client now takes in trace id. Since Diego ssh was not scoped to D-tracing work we just pass an empty trace ID. 

### What problem it is trying to solve?

Being able to trace the same request across multiple components.

### What is the impact if the change is not made?

Difficulty correlating actions happening in different components

### How should this change be described in diego-release release notes?

Add distributed tracing to Diego component logs

### Please provide any contextual information.

https://www.pivotaltracker.com/story/show/183997277

Thank you!
