### PR TITLE
With oss ci export

### DIFF
--- a/bin/test.bash
+++ b/bin/test.bash
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -eu
+set -o pipefail
+
+# shellcheck disable=SC2068
+# Double-quoting array expansion here causes ginkgo to fail
+args=${@} 
+# run integration and store package in serial
+go run github.com/onsi/ginkgo/v2/ginkgo $(echo $args | sed 's/-p //g')

--- a/bin/test.ps1
+++ b/bin/test.ps1
@@ -2,6 +2,7 @@ $ErrorActionPreference = "Stop";
 trap { $host.SetShouldExit(1) }
 
 Write-Host "Downloading winpty DLL"
+Add-Type -AssemblyName System.IO.Compression, System.IO.Compression.FileSystem
 $WINPTY_DIR = "C:\winpty"
 if(!(Test-Path -Path $WINPTY_DIR )) {
     New-Item -ItemType directory -Path $WINPTY_DIR

--- a/bin/test.ps1
+++ b/bin/test.ps1
@@ -1,0 +1,18 @@
+$ErrorActionPreference = "Stop";
+trap { $host.SetShouldExit(1) }
+
+Write-Host "Downloading winpty DLL"
+$WINPTY_DIR = "C:\winpty"
+if(!(Test-Path -Path $WINPTY_DIR )) {
+    New-Item -ItemType directory -Path $WINPTY_DIR
+    (New-Object System.Net.WebClient).DownloadFile('https://github.com/rprichard/winpty/releases/download/0.4.3/winpty-0.4.3-msvc2015.zip', "$WINPTY_DIR\winpty.zip")
+    [System.IO.Compression.ZipFile]::ExtractToDirectory("$WINPTY_DIR\winpty.zip", "$WINPTY_DIR")
+}
+$env:WINPTY_DLL_DIR="$WINPTY_DIR\x64\bin"
+
+Debug "$(gci env:* | sort-object name | Out-String)"
+
+Invoke-Expression "go run github.com/onsi/ginkgo/v2/ginkgo $args"
+if ($LastExitCode -ne 0) {
+  throw "tests failed"
+}

--- a/bin/test.ps1
+++ b/bin/test.ps1
@@ -4,12 +4,12 @@ trap { $host.SetShouldExit(1) }
 Write-Host "Downloading winpty DLL"
 Add-Type -AssemblyName System.IO.Compression, System.IO.Compression.FileSystem
 $WINPTY_DIR = "C:\winpty"
-if(!(Test-Path -Path $WINPTY_DIR )) {
-    New-Item -ItemType directory -Path $WINPTY_DIR
+$env:WINPTY_DLL_DIR="$WINPTY_DIR\x64\bin"
+if(!(Test-Path -Path $env:WINPTY_DLL_DIR )) {
+    New-Item -ItemType directory -Path $WINPTY_DIR -Force
     (New-Object System.Net.WebClient).DownloadFile('https://github.com/rprichard/winpty/releases/download/0.4.3/winpty-0.4.3-msvc2015.zip', "$WINPTY_DIR\winpty.zip")
     [System.IO.Compression.ZipFile]::ExtractToDirectory("$WINPTY_DIR\winpty.zip", "$WINPTY_DIR")
 }
-$env:WINPTY_DLL_DIR="$WINPTY_DIR\x64\bin"
 
 Debug "$(gci env:* | sort-object name | Out-String)"
 

--- a/cmd/ssh-proxy/main_suite_test.go
+++ b/cmd/ssh-proxy/main_suite_test.go
@@ -82,7 +82,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	publicAuthorizedKey = context["authorized-key"]
 
 	node := GinkgoParallelProcess()
-	startPort := 1050 * node
+	startPort := 1070 * node
 	portRange := 1000
 	endPort := startPort + portRange
 

--- a/cmd/ssh-proxy/main_suite_test.go
+++ b/cmd/ssh-proxy/main_suite_test.go
@@ -35,8 +35,6 @@ var (
 	privateKeyPem       string
 	publicAuthorizedKey string
 
-	fixturesPath string
-
 	portAllocator portauthority.PortAllocator
 )
 
@@ -74,8 +72,6 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 
 	err := json.Unmarshal(payload, &context)
 	Expect(err).NotTo(HaveOccurred())
-
-	fixturesPath = "fixtures"
 
 	hostKeyPem = context["host-key"]
 	privateKeyPem = context["private-key"]

--- a/cmd/ssh-proxy/main_suite_test.go
+++ b/cmd/ssh-proxy/main_suite_test.go
@@ -3,8 +3,6 @@ package main_test
 import (
 	"encoding/json"
 	"fmt"
-	"os"
-	"path"
 	"runtime"
 	"testing"
 	"time"
@@ -77,7 +75,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	err := json.Unmarshal(payload, &context)
 	Expect(err).NotTo(HaveOccurred())
 
-	fixturesPath = path.Join(os.Getenv("DIEGO_RELEASE_DIR"), "src/code.cloudfoundry.org/diego-ssh/cmd/ssh-proxy/fixtures")
+	fixturesPath = "fixtures"
 
 	hostKeyPem = context["host-key"]
 	privateKeyPem = context["private-key"]

--- a/cmd/ssh-proxy/main_test.go
+++ b/cmd/ssh-proxy/main_test.go
@@ -68,7 +68,7 @@ var _ = Describe("SSH proxy", func() {
 
 	BeforeEach(func() {
 		var err error
-		certDepoDir, err = ioutil.TempDir("", "")
+		certDepoDir, err = os.MkdirTemp("", "ssh-proxy-certs-")
 		Expect(err).NotTo(HaveOccurred())
 
 		ca, err = certauthority.NewCertAuthority(certDepoDir, "ssh-proxy-ca")

--- a/cmd/ssh-proxy/main_test.go
+++ b/cmd/ssh-proxy/main_test.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -196,7 +195,7 @@ var _ = Describe("SSH proxy", func() {
 		configData, err := json.Marshal(&sshProxyConfig)
 		Expect(err).NotTo(HaveOccurred())
 
-		configFile, err := ioutil.TempFile("", "ssh-proxy-config")
+		configFile, err := os.CreateTemp("", "ssh-proxy-config")
 		Expect(err).NotTo(HaveOccurred())
 
 		n, err := configFile.Write(configData)
@@ -675,6 +674,7 @@ var _ = Describe("SSH proxy", func() {
 
 				errs := make(chan error)
 				go func() {
+					defer GinkgoRecover()
 					for {
 						bs := make([]byte, 10)
 						_, err := client.Read(bs)
@@ -1089,7 +1089,7 @@ func VerifyProto(expected proto.Message) http.HandlerFunc {
 
 		func(w http.ResponseWriter, req *http.Request) {
 			defer GinkgoRecover()
-			body, err := ioutil.ReadAll(req.Body)
+			body, err := io.ReadAll(req.Body)
 			Expect(err).ToNot(HaveOccurred())
 
 			err = req.Body.Close()

--- a/cmd/sshd/main_suite_test.go
+++ b/cmd/sshd/main_suite_test.go
@@ -65,7 +65,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	publicAuthorizedKey = context["authorized-key"]
 
 	node := GinkgoParallelProcess()
-	startPort := 1050 * node
+	startPort := 1070 * node
 	portRange := 1000
 	endPort := startPort + portRange
 

--- a/helpers/http_client_test.go
+++ b/helpers/http_client_test.go
@@ -2,7 +2,6 @@ package helpers_test
 
 import (
 	"crypto/x509"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"time"
@@ -46,7 +45,7 @@ var _ = Describe("NewHTTPSClient", func() {
 
 		BeforeEach(func() {
 			var err error
-			certDepotDir, err = ioutil.TempDir("", "")
+			certDepotDir, err = os.MkdirTemp("", "cert-depot-dir")
 			Expect(err).NotTo(HaveOccurred())
 
 			ca, err = certauthority.NewCertAuthority(certDepotDir, "one")
@@ -63,7 +62,7 @@ var _ = Describe("NewHTTPSClient", func() {
 		It("sets the RootCAs with a pool consisting of those CAs", func() {
 			expectedPool := x509.NewCertPool()
 			for _, caCert := range caCertFiles {
-				certBytes, err := ioutil.ReadFile(caCert)
+				certBytes, err := os.ReadFile(caCert)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(expectedPool.AppendCertsFromPEM(certBytes)).To(BeTrue())
@@ -83,14 +82,14 @@ var _ = Describe("NewHTTPSClient", func() {
 			var invalidCertPath string
 
 			BeforeEach(func() {
-				invalidCert, err := ioutil.TempFile("", "")
+				invalidCert, err := os.CreateTemp("", "invalid-cert-")
 				Expect(err).NotTo(HaveOccurred())
 
 				invalidCertPath = invalidCert.Name()
 
 				Expect(invalidCert.Close()).To(Succeed())
 
-				Expect(ioutil.WriteFile(invalidCertPath, []byte("not valid pem"), 0644)).To(Succeed())
+				Expect(os.WriteFile(invalidCertPath, []byte("not valid pem"), 0644)).To(Succeed())
 
 				caCertFiles = append(caCertFiles, invalidCertPath)
 			})

--- a/helpers/http_client_test.go
+++ b/helpers/http_client_test.go
@@ -62,8 +62,8 @@ var _ = Describe("NewHTTPSClient", func() {
 		It("sets the RootCAs with a pool consisting of those CAs", func() {
 			expectedPool := x509.NewCertPool()
 			for _, caCert := range caCertFiles {
-				certBytes, err := os.ReadFile(caCert)
-				Expect(err).NotTo(HaveOccurred())
+				certBytes, err2 := os.ReadFile(caCert)
+				Expect(err2).NotTo(HaveOccurred())
 
 				Expect(expectedPool.AppendCertsFromPEM(certBytes)).To(BeTrue())
 			}

--- a/server/server_suite_test.go
+++ b/server/server_suite_test.go
@@ -11,7 +11,7 @@ import (
 var portAllocator portauthority.PortAllocator
 var _ = BeforeSuite(func() {
 	node := GinkgoParallelProcess()
-	startPort := 1050 * node
+	startPort := 1070 * node
 	portRange := 1000
 	endPort := startPort + portRange
 


### PR DESCRIPTION
- Fix flakes and race conditions for tests
- Grab a different port so that it doesn't collide with other tests when ran in parallel in windows
