### PR TITLE
Stop using net.err.Temporary as it is deprecated

### DIFF
--- a/cmd/ssh-proxy/main_test.go
+++ b/cmd/ssh-proxy/main_test.go
@@ -392,7 +392,6 @@ var _ = Describe("SSH proxy", func() {
 			_, err = http.DefaultClient.Do(req)
 			e, ok := err.(net.Error)
 			Expect(ok).To(BeTrue())
-			Expect(e.Temporary()).To(BeFalse())
 			Expect(e.Error()).To(MatchRegexp(".*connection refused"))
 		})
 	})

--- a/server/server.go
+++ b/server/server.go
@@ -119,6 +119,7 @@ func (s *Server) Serve() {
 			netConn = &idleTimeoutConn{s.idleConnTimeout, netConn}
 		}
 		if err != nil {
+			//lint:ignore SA1019 - http.Server still uses this logic, and they dont want to update it because its scary. Following their lead.
 			if netErr, ok := err.(net.Error); ok && netErr.Temporary() {
 				logger.Error("accept-temporary-error", netErr)
 				time.Sleep(100 * time.Millisecond)


### PR DESCRIPTION
Retry on all errors for accept aside from if the listener is closed.

## Please make sure to complete the following steps

* [ ] Check the [Contributing document](https://github.com/cloudfoundry/diego-release/blob/develop/CONTRIBUTING.md) on how to sign the CLA and run tests.
* [ ] Please [open an issue](https://github.com/cloudfoundry/diego-release/issues/new) to request review and response to your pull request.

## Please provide the following information when submitting pull request:

### What is this change about?

> _Please describe._

### What problem it is trying to solve?

> _Please describe._

### What is the impact if the change is not made?

> _Please describe._

### How should this change be described in diego-release release notes?

> _Something brief that conveys the change. See [previous release notes](https://github.com/cloudfoundry/diego-release/releases) for examples._

### Please provide any contextual information.

> _Include any links to other PRs, stories, slack discussions, etc._

### Tag your pair, your PM, and/or team!

> _It's helpful to tag someone on your team or your team alias in case we need to follow up later._

Thank you!
