### PR TITLE
Fix diego-sshd tests

### DIFF
--- a/authenticators/cf_authenticator.go
+++ b/authenticators/cf_authenticator.go
@@ -91,12 +91,9 @@ func (cfa *CFAuthenticator) Authenticate(metadata ssh.ConnMetadata, password []b
 	tokenString := parts[1]
 	// When parsing the certificate validating the signature is not required and we don't readily have the
 	// certificate to validate the signature.  This is just to parse the second information part of the token anyway.
-	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
+	token, _ := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
 		return []byte("Doesntmatter"), nil
 	})
-	if err != nil {
-		return nil, err
-	}
 
 	username, ok := token.Claims.(jwt.MapClaims)["user_name"].(string)
 	if !ok {

--- a/cmd/ssh-proxy/main_test.go
+++ b/cmd/ssh-proxy/main_test.go
@@ -980,7 +980,7 @@ var _ = Describe("SSH proxy", func() {
 		})
 	})
 
-	Describe("authenticating with the cf realm with a one time code", func() {
+	Describe("authenticating with the cf realm with a one time code", Serial, func() {
 		BeforeEach(func() {
 			clientConfig = &ssh.ClientConfig{
 				User:            "cf:60f0f26e-86b3-4487-8f19-9e94f848f3d2/99",
@@ -1052,7 +1052,7 @@ var _ = Describe("SSH proxy", func() {
 			Expect(string(output)).To(Equal("hello"))
 		})
 
-		Context("when the proxy is configured to use direct instance address", func() {
+		Context("when the proxy is configured to use direct instance address", Serial, func() {
 			BeforeEach(func() {
 				sshProxyConfig.ConnectToInstanceAddress = true
 


### PR DESCRIPTION
- Don't check errors on jwt parsing, we use it only for parsing info, not auth
- Serialize tests that all use the same sshdContainerPort so they are no longer stepping on eachother
 
Thank you for submitting a pull request to the diego-ssh repository. We appreciate the contribution. To help us with getting better context for the pull request please follow these guidelines:

## Please make sure to complete the following steps

* [ ] Check the [Contributing document](https://github.com/cloudfoundry/diego-release/blob/develop/CONTRIBUTING.md) on how to sign the CLA and run tests.
* [ ] Please [open an issue](https://github.com/cloudfoundry/diego-release/issues/new) to request review and response to your pull request.

## Please provide the following information when submitting pull request:

### What is this change about?

> _Please describe._

### What problem it is trying to solve?

> _Please describe._

### What is the impact if the change is not made?

> _Please describe._

### How should this change be described in diego-release release notes?

> _Something brief that conveys the change. See [previous release notes](https://github.com/cloudfoundry/diego-release/releases) for examples._

### Please provide any contextual information.

> _Include any links to other PRs, stories, slack discussions, etc._

### Tag your pair, your PM, and/or team!

> _It's helpful to tag someone on your team or your team alias in case we need to follow up later._

Thank you!
