### PR TITLE
Add Support for SHA256 in diego-ssh

### DIFF
--- a/helpers/fingerprint.go
+++ b/helpers/fingerprint.go
@@ -2,6 +2,7 @@ package helpers
 
 import (
 	"crypto/md5"
+	"crypto/sha1"
 	"crypto/sha256"
 	"fmt"
 	"strings"
@@ -10,6 +11,7 @@ import (
 )
 
 const MD5_FINGERPRINT_LENGTH = 47
+const SHA1_FINGERPRINT_LENGTH = 59
 const SHA256_FINGERPRINT_LENGTH = 95
 
 func MD5Fingerprint(key ssh.PublicKey) string {
@@ -20,6 +22,11 @@ func MD5Fingerprint(key ssh.PublicKey) string {
 func SHA256Fingerprint(key ssh.PublicKey) string {
 	sha256sum := sha256.Sum256(key.Marshal())
 	return colonize(fmt.Sprintf("% x", sha256sum))
+}
+
+func SHA1Fingerprint(key ssh.PublicKey) string {
+	sha1sum := sha1.Sum(key.Marshal())
+	return colonize(fmt.Sprintf("% x", sha1sum))
 }
 
 func colonize(s string) string {

--- a/helpers/fingerprint.go
+++ b/helpers/fingerprint.go
@@ -18,8 +18,8 @@ func MD5Fingerprint(key ssh.PublicKey) string {
 }
 
 func SHA256Fingerprint(key ssh.PublicKey) string {
-	sha1sum := sha256.Sum256(key.Marshal())
-	return colonize(fmt.Sprintf("% x", sha1sum))
+	sha256sum := sha256.Sum256(key.Marshal())
+	return colonize(fmt.Sprintf("% x", sha256sum))
 }
 
 func colonize(s string) string {

--- a/helpers/fingerprint.go
+++ b/helpers/fingerprint.go
@@ -2,7 +2,7 @@ package helpers
 
 import (
 	"crypto/md5"
-	"crypto/sha1"
+	"crypto/sha256"
 	"fmt"
 	"strings"
 
@@ -10,15 +10,15 @@ import (
 )
 
 const MD5_FINGERPRINT_LENGTH = 47
-const SHA1_FINGERPRINT_LENGTH = 59
+const SHA256_FINGERPRINT_LENGTH = 95
 
 func MD5Fingerprint(key ssh.PublicKey) string {
 	md5sum := md5.Sum(key.Marshal())
 	return colonize(fmt.Sprintf("% x", md5sum))
 }
 
-func SHA1Fingerprint(key ssh.PublicKey) string {
-	sha1sum := sha1.Sum(key.Marshal())
+func SHA256Fingerprint(key ssh.PublicKey) string {
+	sha1sum := sha256.Sum256(key.Marshal())
 	return colonize(fmt.Sprintf("% x", sha1sum))
 }
 

--- a/helpers/fingerprint_test.go
+++ b/helpers/fingerprint_test.go
@@ -40,6 +40,7 @@ HbXzxBM4Ki0l1kaUjDVKjz3fsIq9Pl/lBoKYAmDvkK4xoxcs05ws
 -----END RSA PRIVATE KEY-----`
 
 	ExpectedMD5Fingerprint    = `24:2e:53:c3:72:4f:25:b8:72:29:2d:e3:56:63:4b:c8`
+	ExpectedSHA1Fingerprint   = `8b:d1:ce:b8:3a:f0:37:7f:56:9e:33:1a:72:4b:32:5a:bc:9d:3b:49`
 	ExpectedSHA256Fingerprint = `c7:e1:1c:47:3b:7b:11:f5:6e:5d:3c:67:16:dd:35:96:4c:5a:6c:f5:0b:82:e5:20:a6:f7:29:a3:9d:bf:3e:e7`
 )
 
@@ -65,6 +66,20 @@ var _ = Describe("Fingerprint", func() {
 
 		It("should match the expected fingerprint", func() {
 			Expect(fingerprint).To(Equal(ExpectedMD5Fingerprint))
+		})
+	})
+
+	Describe("SHA1 Fingerprint", func() {
+		BeforeEach(func() {
+			fingerprint = helpers.SHA1Fingerprint(publicKey)
+		})
+
+		It("should have the correct length", func() {
+			Expect(utf8.RuneCountInString(fingerprint)).To(Equal(helpers.SHA1_FINGERPRINT_LENGTH))
+		})
+
+		It("should match the expected fingerprint", func() {
+			Expect(fingerprint).To(Equal(ExpectedSHA1Fingerprint))
 		})
 	})
 

--- a/helpers/fingerprint_test.go
+++ b/helpers/fingerprint_test.go
@@ -39,8 +39,8 @@ feuxbZkmphtEOKtaVDSWxGbNXbuN8H9eQqsGhK1Xcn/FxKVu7k+9GYyqeOwhjaqy
 HbXzxBM4Ki0l1kaUjDVKjz3fsIq9Pl/lBoKYAmDvkK4xoxcs05ws
 -----END RSA PRIVATE KEY-----`
 
-	ExpectedMD5Fingerprint  = `24:2e:53:c3:72:4f:25:b8:72:29:2d:e3:56:63:4b:c8`
-	ExpectedSHA1Fingerprint = `8b:d1:ce:b8:3a:f0:37:7f:56:9e:33:1a:72:4b:32:5a:bc:9d:3b:49`
+	ExpectedMD5Fingerprint    = `24:2e:53:c3:72:4f:25:b8:72:29:2d:e3:56:63:4b:c8`
+	ExpectedSHA256Fingerprint = `c7:e1:1c:47:3b:7b:11:f5:6e:5d:3c:67:16:dd:35:96:4c:5a:6c:f5:0b:82:e5:20:a6:f7:29:a3:9d:bf:3e:e7`
 )
 
 var _ = Describe("Fingerprint", func() {
@@ -68,17 +68,17 @@ var _ = Describe("Fingerprint", func() {
 		})
 	})
 
-	Describe("SHA1 Fingerprint", func() {
+	Describe("SHA256 Fingerprint", func() {
 		BeforeEach(func() {
-			fingerprint = helpers.SHA1Fingerprint(publicKey)
+			fingerprint = helpers.SHA256Fingerprint(publicKey)
 		})
 
 		It("should have the correct length", func() {
-			Expect(utf8.RuneCountInString(fingerprint)).To(Equal(helpers.SHA1_FINGERPRINT_LENGTH))
+			Expect(utf8.RuneCountInString(fingerprint)).To(Equal(helpers.SHA256_FINGERPRINT_LENGTH))
 		})
 
 		It("should match the expected fingerprint", func() {
-			Expect(fingerprint).To(Equal(ExpectedSHA1Fingerprint))
+			Expect(fingerprint).To(Equal(ExpectedSHA256Fingerprint))
 		})
 	})
 })

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -401,8 +401,8 @@ func NewClientConn(logger lager.Logger, permissions *ssh.Permissions, tlsConfig 
 			switch utf8.RuneCountInString(expectedFingerprint) {
 			case helpers.MD5_FINGERPRINT_LENGTH:
 				actualFingerprint = helpers.MD5Fingerprint(key)
-			case helpers.SHA1_FINGERPRINT_LENGTH:
-				actualFingerprint = helpers.SHA1Fingerprint(key)
+			case helpers.SHA256_FINGERPRINT_LENGTH:
+				actualFingerprint = helpers.SHA256Fingerprint(key)
 			}
 
 			if expectedFingerprint != actualFingerprint {

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -401,6 +401,8 @@ func NewClientConn(logger lager.Logger, permissions *ssh.Permissions, tlsConfig 
 			switch utf8.RuneCountInString(expectedFingerprint) {
 			case helpers.MD5_FINGERPRINT_LENGTH:
 				actualFingerprint = helpers.MD5Fingerprint(key)
+			case helpers.SHA1_FINGERPRINT_LENGTH:
+				actualFingerprint = helpers.SHA1Fingerprint(key)
 			case helpers.SHA256_FINGERPRINT_LENGTH:
 				actualFingerprint = helpers.SHA256Fingerprint(key)
 			}

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -248,7 +248,7 @@ var _ = Describe("Proxy", func() {
 						BeforeEach(func() {
 							targetConfigJson, err := json.Marshal(proxy.TargetConfig{
 								Address:         sshdListener.Addr().String(),
-								HostFingerprint: helpers.SHA1Fingerprint(TestHostKey.PublicKey()),
+								HostFingerprint: helpers.SHA256Fingerprint(TestHostKey.PublicKey()),
 								User:            "some-user",
 								Password:        "fake-some-password",
 							})


### PR DESCRIPTION
SHA256 is a more secure hashing algorithm and should be used to replace usage of SHA1. This PR will allow backwards compatibility with older versions. 

The functionality of this PR is incomplete until CAPI begins sending SHA256 fingerprint keys to us. 