### PR TITLE
Remove chacha20 cipher 

### DIFF
--- a/cmd/ssh-proxy/main.go
+++ b/cmd/ssh-proxy/main.go
@@ -193,7 +193,7 @@ func configureProxy(logger lager.Logger, sshProxyConfig config.SSHProxyConfig) (
 	if sshProxyConfig.AllowedCiphers != "" {
 		sshConfig.Config.Ciphers = strings.Split(sshProxyConfig.AllowedCiphers, ",")
 	} else {
-		sshConfig.Config.Ciphers = []string{"chacha20-poly1305@openssh.com", "aes128-gcm@openssh.com", "aes256-ctr", "aes192-ctr", "aes128-ctr"}
+		sshConfig.Config.Ciphers = []string{"aes128-gcm@openssh.com", "aes256-ctr", "aes192-ctr", "aes128-ctr"}
 	}
 
 	if sshProxyConfig.AllowedMACs != "" {

--- a/cmd/ssh-proxy/main_test.go
+++ b/cmd/ssh-proxy/main_test.go
@@ -781,9 +781,9 @@ var _ = Describe("SSH proxy", Serial, func() {
 				clientConfig.Ciphers = []string{"arcfour128"}
 			})
 
-			It("errors when the client doesn't provide any of the algorithms: 'chacha20-poly1305@openssh.com', 'aes128-gcm@openssh.com', 'aes128-gcm@openssh.com', 'aes256-ctr', 'aes192-ctr', 'aes128-ctr'", func() {
+			It("errors when the client doesn't provide any of the algorithms: 'aes128-gcm@openssh.com', 'aes128-gcm@openssh.com', 'aes256-ctr', 'aes192-ctr', 'aes128-ctr'", func() {
 				_, err := ssh.Dial("tcp", address, clientConfig)
-				Expect(err).To(MatchError("ssh: handshake failed: ssh: no common algorithm for client to server cipher; client offered: [arcfour128], server offered: [chacha20-poly1305@openssh.com aes128-gcm@openssh.com aes256-ctr aes192-ctr aes128-ctr]"))
+				Expect(err).To(MatchError("ssh: handshake failed: ssh: no common algorithm for client to server cipher; client offered: [arcfour128], server offered: [aes128-gcm@openssh.com aes256-ctr aes192-ctr aes128-ctr]"))
 				Expect(fakeBBS.ReceivedRequests()).To(HaveLen(0))
 			})
 		})

--- a/cmd/sshd/main.go
+++ b/cmd/sshd/main.go
@@ -249,7 +249,7 @@ func configure(logger lager.Logger) (*ssh.ServerConfig, error) {
 	if *allowedCiphers != "" {
 		sshConfig.Config.Ciphers = strings.Split(*allowedCiphers, ",")
 	} else {
-		sshConfig.Config.Ciphers = []string{"chacha20-poly1305@openssh.com", "aes128-gcm@openssh.com", "aes256-ctr", "aes192-ctr", "aes128-ctr"}
+		sshConfig.Config.Ciphers = []string{"aes128-gcm@openssh.com", "aes256-ctr", "aes192-ctr", "aes128-ctr"}
 	}
 
 	if *allowedMACs != "" {

--- a/cmd/sshd/main_test.go
+++ b/cmd/sshd/main_test.go
@@ -406,8 +406,8 @@ var _ = Describe("SSH daemon", func() {
 				Expect(process).NotTo(BeNil())
 			})
 
-			It("errors when the client doesn't provide one of the algorithm: 'chacha20-poly1305@openssh.com', 'aes128-gcm@openssh.com', 'aes256-ctr', 'aes192-ctr', 'aes128-ctr'", func() {
-				Expect(dialErr).To(MatchError("ssh: handshake failed: ssh: no common algorithm for client to server cipher; client offered: [arcfour128], server offered: [chacha20-poly1305@openssh.com aes128-gcm@openssh.com aes256-ctr aes192-ctr aes128-ctr]"))
+			It("errors when the client doesn't provide one of the algorithm: 'aes128-gcm@openssh.com', 'aes256-ctr', 'aes192-ctr', 'aes128-ctr'", func() {
+				Expect(dialErr).To(MatchError("ssh: handshake failed: ssh: no common algorithm for client to server cipher; client offered: [arcfour128], server offered: [aes128-gcm@openssh.com aes256-ctr aes192-ctr aes128-ctr]"))
 				Expect(client).To(BeNil())
 			})
 		})


### PR DESCRIPTION
Remove chacha20 cipher from cmd/ssh-proxy/main.go and cmd/sshd/main.go files in accordance to SAP security standards in order to prevent vulnerabilities related to terapin attacks.

Related BLI: https://jira.tools.sap/browse/CFAR-1064

Changes have been applied and tested on a dev landscape using a custom diego release.

