### PR TITLE
Use the correct package for SHA256

### DIFF
--- a/helpers/fingerprint.go
+++ b/helpers/fingerprint.go
@@ -3,7 +3,6 @@ package helpers
 import (
 	"crypto/md5"
 	"crypto/sha1"
-	"crypto/sha256"
 	"fmt"
 	"strings"
 
@@ -12,7 +11,7 @@ import (
 
 const MD5_FINGERPRINT_LENGTH = 47
 const SHA1_FINGERPRINT_LENGTH = 59
-const SHA256_FINGERPRINT_LENGTH = 95
+const SHA256_FINGERPRINT_LENGTH = 44 //unpaded base64
 
 func MD5Fingerprint(key ssh.PublicKey) string {
 	md5sum := md5.Sum(key.Marshal())
@@ -20,8 +19,8 @@ func MD5Fingerprint(key ssh.PublicKey) string {
 }
 
 func SHA256Fingerprint(key ssh.PublicKey) string {
-	sha256sum := sha256.Sum256(key.Marshal())
-	return colonize(fmt.Sprintf("% x", sha256sum))
+	value := ssh.FingerprintSHA256(key)
+	return strings.TrimPrefix(value, "SHA256:")
 }
 
 func SHA1Fingerprint(key ssh.PublicKey) string {

--- a/helpers/fingerprint.go
+++ b/helpers/fingerprint.go
@@ -11,7 +11,7 @@ import (
 
 const MD5_FINGERPRINT_LENGTH = 47
 const SHA1_FINGERPRINT_LENGTH = 59
-const SHA256_FINGERPRINT_LENGTH = 44 //unpaded base64
+const SHA256_FINGERPRINT_LENGTH = 44 //unpadded base64
 
 func MD5Fingerprint(key ssh.PublicKey) string {
 	md5sum := md5.Sum(key.Marshal())

--- a/helpers/fingerprint_test.go
+++ b/helpers/fingerprint_test.go
@@ -1,6 +1,7 @@
 package helpers_test
 
 import (
+	"fmt"
 	"unicode/utf8"
 
 	"code.cloudfoundry.org/diego-ssh/helpers"
@@ -41,7 +42,7 @@ HbXzxBM4Ki0l1kaUjDVKjz3fsIq9Pl/lBoKYAmDvkK4xoxcs05ws
 
 	ExpectedMD5Fingerprint    = `24:2e:53:c3:72:4f:25:b8:72:29:2d:e3:56:63:4b:c8`
 	ExpectedSHA1Fingerprint   = `8b:d1:ce:b8:3a:f0:37:7f:56:9e:33:1a:72:4b:32:5a:bc:9d:3b:49`
-	ExpectedSHA256Fingerprint = `c7:e1:1c:47:3b:7b:11:f5:6e:5d:3c:67:16:dd:35:96:4c:5a:6c:f5:0b:82:e5:20:a6:f7:29:a3:9d:bf:3e:e7`
+	ExpectedSHA256Fingerprint = `x+EcRzt7EfVuXTxnFt01lkxabPULguUgpvcpo52/Puc=`
 )
 
 var _ = Describe("Fingerprint", func() {
@@ -85,7 +86,7 @@ var _ = Describe("Fingerprint", func() {
 
 	Describe("SHA256 Fingerprint", func() {
 		BeforeEach(func() {
-			fingerprint = helpers.SHA256Fingerprint(publicKey)
+			fingerprint = fmt.Sprintf("%s=", helpers.SHA256Fingerprint(publicKey))
 		})
 
 		It("should have the correct length", func() {

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"strings"
 	"sync"
 	"unicode/utf8"
 
@@ -405,6 +406,8 @@ func NewClientConn(logger lager.Logger, permissions *ssh.Permissions, tlsConfig 
 				actualFingerprint = helpers.SHA1Fingerprint(key)
 			case helpers.SHA256_FINGERPRINT_LENGTH:
 				actualFingerprint = helpers.SHA256Fingerprint(key)
+				//sshkey ruby gem pads the base64 output, but golang implementation returns unpaded
+				expectedFingerprint = strings.TrimRight(expectedFingerprint, "=")
 			}
 
 			if expectedFingerprint != actualFingerprint {

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"os"
@@ -271,7 +272,7 @@ var _ = Describe("Proxy", func() {
 						BeforeEach(func() {
 							targetConfigJson, err := json.Marshal(proxy.TargetConfig{
 								Address:         sshdListener.Addr().String(),
-								HostFingerprint: helpers.SHA256Fingerprint(TestHostKey.PublicKey()),
+								HostFingerprint: fmt.Sprintf("%s=", helpers.SHA256Fingerprint(TestHostKey.PublicKey())),
 								User:            "some-user",
 								Password:        "fake-some-password",
 							})


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
for SHA256 the accepted value is a base64 encoded value instead of hex pair.



Backward Compatibility
---------------
Breaking Change? **No**
